### PR TITLE
Improvements in the UserStore authentication health probe

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/health/userstore/UserStoreAuthenticationHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/userstore/UserStoreAuthenticationHealthProbe.java
@@ -2,16 +2,21 @@ package uk.gov.hmcts.reform.idam.health.userstore;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.ldap.core.AttributesMapper;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.idam.health.probe.HealthProbe;
 import uk.gov.hmcts.reform.idam.health.props.ProbeUserProperties;
+
+import javax.naming.directory.SearchControls;
+import java.util.List;
 
 @Component
 @Profile("userstore")
 @Slf4j
 public class UserStoreAuthenticationHealthProbe implements HealthProbe {
 
+    private static final String LDAP_CN_ATTRIBUTE = "cn";
     private final String TAG = "UserStore Auth: ";
 
     private static final String LDAP_PARTITION_SUFFIX = "dc=reform,dc=hmcts,dc=net";
@@ -34,6 +39,14 @@ public class UserStoreAuthenticationHealthProbe implements HealthProbe {
     @Override
     public boolean probe() {
         try {
+            List<String> testUsers = ldapTemplate.search(LDAP_PARTITION_SUFFIX,
+                    ldapUserFilter,
+                    SearchControls.SUBTREE_SCOPE,
+                    (AttributesMapper<String>) attrs -> attrs.get(LDAP_CN_ATTRIBUTE).get().toString());
+            if (testUsers.isEmpty()) {
+                log.warn(TAG + "test user does not exist");
+                return true;
+            }
             boolean isAuthenticationSuccessful = ldapTemplate.authenticate(
                     LDAP_PARTITION_SUFFIX,
                     ldapUserFilter,

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/userstore/UserStoreAuthenticationHealthProbeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/userstore/UserStoreAuthenticationHealthProbeTest.java
@@ -7,11 +7,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.ldap.BadLdapGrammarException;
+import org.springframework.ldap.core.AttributesMapper;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.NameClassPairCallbackHandler;
 import uk.gov.hmcts.reform.idam.health.props.ProbeUserProperties;
 
+import javax.naming.directory.SearchControls;
+
+import java.util.Collections;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -30,12 +39,19 @@ public class UserStoreAuthenticationHealthProbeTest {
     public void setup() {
         when(probeUserProperties.getUsername()).thenReturn("test-username");
         when(probeUserProperties.getPassword()).thenReturn("test-password");
+        when(ldapTemplate.search(anyString(), anyString(), any(int.class), any(AttributesMapper.class))).thenReturn(singletonList("test-username"));
         probe = new UserStoreAuthenticationHealthProbe(ldapTemplate, probeUserProperties);
     }
 
     @Test
     public void testProbe_success() {
         when(ldapTemplate.authenticate(anyString(), anyString(), anyString())).thenReturn(true);
+        assertThat(probe.probe(), is(true));
+    }
+
+    @Test
+    public void testProbe_userDoesNotExist() {
+        when(ldapTemplate.search(anyString(), anyString(), any(int.class), any(AttributesMapper.class))).thenReturn(emptyList());
         assertThat(probe.probe(), is(true));
     }
 


### PR DESCRIPTION
Keep the node up if the test user does not exist.