### PR TITLE
experiments with ldap replication attributes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.idam.health.ldap;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Profile;
-import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.ContextMapper;
+import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.query.LdapQuery;
 import org.springframework.ldap.query.LdapQueryBuilder;
@@ -11,13 +13,11 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.idam.health.probe.HealthProbe;
 import uk.gov.hmcts.reform.idam.health.props.ConfigProperties;
 
+import javax.naming.Name;
 import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -30,18 +30,28 @@ public class LdapReplicationHealthProbe implements HealthProbe {
     private static final String STATUS_ATTRIBUTE = "status";
     private static final String PENDING_UPDATES_ATTRIBUTE = "pending-updates";
     private static final String MISSING_CHANGES_ATTRIBUTE = "missing-changes";
+    private static final String APPROXIMATE_DELAY_ATTRIBUTE = "approximate-delay";
+    private static final String RECEIVED_UPDATES_ATTRIBUTE = "received-updates";
+    private static final String REPLAYED_UPDATES_ATTRIBUTE = "replayed-updates";
     private static final String REPLICATION_FILTER = "(&(objectClass=*)(domain-name=dc=reform,dc=hmcts,dc=net))";
     private static final String NORMAL_STATUS = "normal";
 
+    private static final List<String> EXCLUDED_CNS = new ArrayList<>();
+    static {
+        EXCLUDED_CNS.add("cn=monitor");
+        EXCLUDED_CNS.add("cn=Replication");
+        EXCLUDED_CNS.add("cn=dc_reform_dc_hmcts_dc_net");
+    }
+
     private final LdapTemplate ldapTemplate;
     private final ConfigProperties.Ldap ldapProperties;
-    private final ReplicationAttributeMapper replicationAttributeMapper;
+    private final ReplicationContextMapper replicationContextMapper;
 
     public LdapReplicationHealthProbe(
             LdapTemplate ldapTemplate,
             ConfigProperties configProperties) {
         this.ldapTemplate = ldapTemplate;
-        this.replicationAttributeMapper = new ReplicationAttributeMapper();
+        this.replicationContextMapper = new ReplicationContextMapper();
         this.ldapProperties = configProperties.getLdap();
     }
 
@@ -51,21 +61,44 @@ public class LdapReplicationHealthProbe implements HealthProbe {
             LdapQuery replicationQuery = LdapQueryBuilder.query()
                     .base(BASE_DN)
                     .searchScope(SearchScope.SUBTREE)
-                    .attributes(STATUS_ATTRIBUTE, PENDING_UPDATES_ATTRIBUTE, MISSING_CHANGES_ATTRIBUTE)
+                    .attributes(STATUS_ATTRIBUTE, PENDING_UPDATES_ATTRIBUTE, MISSING_CHANGES_ATTRIBUTE, APPROXIMATE_DELAY_ATTRIBUTE, RECEIVED_UPDATES_ATTRIBUTE, REPLAYED_UPDATES_ATTRIBUTE)
                     .filter(REPLICATION_FILTER);
 
-            List<ReplicationInfo> replicationData = ldapTemplate.search(replicationQuery, replicationAttributeMapper);
-            if (replicationData.stream().noneMatch(info -> NORMAL_STATUS.equalsIgnoreCase(info.status))) {
-                log.error(TAG + "Failing status checks, " + toString(summarize(replicationData)));
-                return false;
+            List<ReplicationInfo> replicationDataList = ldapTemplate.search(replicationQuery, replicationContextMapper);
+
+            boolean result = true;
+            for (ReplicationInfo replicationData : replicationDataList) {
+                if (replicationData.changelog) {
+                    continue;
+                }
+
+                if (replicationData.infoRecordType == InfoRecordType.SELF_DIR) {
+
+                    if ((replicationData.status != null) && (NORMAL_STATUS.equals(replicationData.status))) {
+                        log.error(TAG + "Failing status checks, " + replicationData.toString());
+                        result = false;
+                    } else {
+                        log.info(TAG + replicationData.infoRecordType + " okay, " + replicationData.toString());
+                    }
+
+                } else if (replicationData.infoRecordType != InfoRecordType.UNKNOWN) {
+
+                    if (!isReplicationInGoodState(replicationData)) {
+                        log.error(TAG + "Failing good state checks, " + replicationData.toString());
+                        result = false;
+                    } else {
+                        log.info(TAG + replicationData.infoRecordType + " okay, " + replicationData.toString());
+                    }
+
+                } else {
+
+                    log.warn(TAG + "Unknown replication record, " + replicationData.toString());
+
+                }
+
             }
-            if (replicationData.stream().allMatch(this::isReplicationInGoodState)) {
-                log.info(TAG + "success, checked " + replicationData.size() + " results");
-                return true;
-            } else {
-                log.error(TAG + "Failing missing or pending changes, " + toString(summarize(replicationData)));
-                return false;
-            }
+            return result;
+
         } catch (Exception e) {
             log.error(TAG +  e.getMessage() + " [" + e.getClass().getSimpleName() + "]");
         }
@@ -77,62 +110,130 @@ public class LdapReplicationHealthProbe implements HealthProbe {
                 && info.pendingUpdates <= this.ldapProperties.getReplication().getPendingUpdatesThreshold();
     }
 
-    private Map<String, Integer> summarize(List<ReplicationInfo> replicationData) {
-        Map<String, Integer> summary = new HashMap<>();
-        int maxMissing = 0, maxPending = 0;
-        for (ReplicationInfo replicationDatum : replicationData) {
-            increment(summary, "status-" + replicationDatum.status, 1);
-            increment(summary, replicationDatum.status + "-missing", replicationDatum.missingChanges);
-            increment(summary, replicationDatum.status + "-pending", replicationDatum.pendingUpdates);
-            if (maxMissing < replicationDatum.missingChanges) {
-                maxMissing = replicationDatum.missingChanges;
-            }
-            if (maxPending < replicationDatum.pendingUpdates) {
-                maxPending = replicationDatum.pendingUpdates;
-            }
-        }
-        summary.put("maxMissing", maxMissing);
-        summary.put("maxPending", maxPending);
-        return summary;
-    }
-
-    private String toString(Map<String, Integer> summary) {
-        if (!summary.isEmpty()) {
-            return summary.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(","));
-        }
-        return "no replication info";
-    }
-
-    private void increment(Map<String, Integer> summary, String key, int value) {
-        Integer statusCount = summary.get(key);
-        if (statusCount == null) {
-            statusCount = value;
-        } else {
-            statusCount += value;
-        }
-        summary.put(key, statusCount);
-    }
-
     static class ReplicationInfo {
+        protected InfoRecordType infoRecordType;
+        protected String dn;
+        protected boolean changelog;
+        protected List<String> cn;
+        protected String connectedReplicationServer;
+        protected String connectedDirectoryServer;
+        protected String directoryServer;
+        protected String replicationServer;
         protected String status;
         protected Integer pendingUpdates;
         protected Integer missingChanges;
-    }
-
-    static class ReplicationAttributeMapper implements AttributesMapper<ReplicationInfo> {
+        protected Integer approximateDelay;
+        protected Integer receivedUpdates;
+        protected Integer replayedUpdates;
 
         @Override
-        public ReplicationInfo mapFromAttributes(Attributes attributes) throws NamingException {
-            Attribute statusAttribute = attributes.get(STATUS_ATTRIBUTE);
-            Attribute pendingUpdatesAttribute = attributes.get(PENDING_UPDATES_ATTRIBUTE);
-            Attribute missingChangesAttribute = attributes.get(MISSING_CHANGES_ATTRIBUTE);
+        public String toString() {
+            List<String> display = new ArrayList<>();
+            if (replicationServer != null) {
+                display.add("repl-server:" + replicationServer);
+            }
+            if (directoryServer != null) {
+                display.add("dir-server:" + directoryServer);
+            }
+            if (connectedReplicationServer != null) {
+                display.add("repl-connected:" + connectedReplicationServer);
+            }
+            if (connectedDirectoryServer != null) {
+                display.add("dir-connected:" + connectedDirectoryServer);
+            }
+            if (display.isEmpty()) {
+                display.add("dn:" + dn);
+            }
+            display.add("status:" + status);
+            display.add("pending:" + pendingUpdates);
+            display.add("missing:" + missingChanges);
+            display.add("received:" + receivedUpdates);
+            display.add("replayed:" + replayedUpdates);
+            display.add("delay:" + approximateDelay);
+            return String.join(",", display);
+        }
+    }
+
+    enum InfoRecordType {
+        SELF_REPL, SELF_DIR, SELF_BOTH, OTHER_REPL, OTHER_DIR, OTHER_BOTH, UNKNOWN;
+    }
+
+    static class ReplicationContextMapper implements ContextMapper<ReplicationInfo> {
+
+        @Override
+        public ReplicationInfo mapFromContext(Object ctx) throws NamingException {
+            DirContextAdapter context = (DirContextAdapter)ctx;
+            Name dn = context.getDn();
+            String statusAttribute = context.getStringAttribute(STATUS_ATTRIBUTE);
+            String pendingUpdatesAttribute = context.getStringAttribute(PENDING_UPDATES_ATTRIBUTE);
+            String missingChangesAttribute = context.getStringAttribute(MISSING_CHANGES_ATTRIBUTE);
+            String approximateDelay = context.getStringAttribute(APPROXIMATE_DELAY_ATTRIBUTE);
+            String receivedUpdates = context.getStringAttribute(RECEIVED_UPDATES_ATTRIBUTE);
+            String replayedUpdates = context.getStringAttribute(REPLAYED_UPDATES_ATTRIBUTE);
+
+            boolean changelog = false;
+            String connectedReplicationServer = null;
+            String connectedDirectoryServer = null;
+            String replicationServer = null;
+            String directoryServer = null;
+            List<String> usefulCn = new ArrayList<>();
+            for(Enumeration<String> e = dn.getAll(); e.hasMoreElements();) {
+                String value = e.nextElement();
+                if (!EXCLUDED_CNS.contains(value)) {
+                    if (value.startsWith("cn=Changelog")) {
+                        changelog = true;
+                    } else if (value.startsWith("cn=Connected replication server")) {
+                        connectedReplicationServer = value.split("\\) ")[1];
+                    } else if (value.startsWith("cn=Connected directory server")) {
+                        connectedDirectoryServer = value.split("\\) ")[1];
+                    } else if (value.startsWith("cn=Directory server")) {
+                        directoryServer = value.split("\\) ")[1];
+                    } else if (value.startsWith("cn=Replication server")) {
+                        replicationServer = value.split("\\) ")[1];
+                    }
+                    usefulCn.add(value);
+                }
+            }
 
             ReplicationInfo result = new ReplicationInfo();
-            result.status = statusAttribute == null ? null : statusAttribute.get().toString();
-            result.pendingUpdates = pendingUpdatesAttribute == null ? 0 : Integer.valueOf(pendingUpdatesAttribute.get().toString());
-            result.missingChanges = missingChangesAttribute == null ? 0 : Integer.valueOf(missingChangesAttribute.get().toString());
+            result.dn = dn.toString();
+            result.cn = usefulCn;
+            result.connectedReplicationServer = connectedReplicationServer;
+            result.connectedDirectoryServer = connectedDirectoryServer;
+            result.directoryServer = directoryServer;
+            result.replicationServer = replicationServer;
+            result.changelog = changelog;
+            result.status = statusAttribute;
+            result.pendingUpdates = toInt(pendingUpdatesAttribute);
+            result.missingChanges = toInt(missingChangesAttribute);
+            result.approximateDelay = toInt(approximateDelay);
+            result.receivedUpdates = toInt(receivedUpdates);
+            result.replayedUpdates = toInt(replayedUpdates);
+            result.infoRecordType = getType(replicationServer, directoryServer, connectedReplicationServer, connectedDirectoryServer);
 
             return result;
+        }
+
+        public Integer toInt(String value) {
+            return value == null ? -1 : Integer.valueOf(value);
+        }
+
+        public InfoRecordType getType(String replServer, String dirServer, String connectedReplServer, String connectedDirServer) {
+            if (StringUtils.isNoneEmpty(connectedReplServer, connectedDirServer)) {
+                return InfoRecordType.OTHER_BOTH;
+            } else if (StringUtils.isNotEmpty(connectedReplServer)) {
+                return InfoRecordType.OTHER_REPL;
+            } else if (StringUtils.isNotEmpty(connectedDirServer)) {
+                return InfoRecordType.OTHER_DIR;
+            } else if (StringUtils.isNoneEmpty(replServer, dirServer)) {
+                return InfoRecordType.SELF_BOTH;
+            } else if (StringUtils.isNotEmpty(replServer)) {
+                return InfoRecordType.SELF_REPL;
+            } else if (StringUtils.isNotEmpty(dirServer)) {
+                return InfoRecordType.SELF_DIR;
+            } else {
+                return InfoRecordType.UNKNOWN;
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
@@ -34,7 +34,7 @@ public class LdapReplicationHealthProbe implements HealthProbe {
     private static final String SENT_UPDATES_ATTRIBUTE = "sent-updates";
     private static final String RECEIVED_UPDATES_ATTRIBUTE = "received-updates";
     private static final String REPLAYED_UPDATES_ATTRIBUTE = "replayed-updates";
-    private static final String REPLICATION_FILTER = "(&(objectClass=*)(domain-name=dc=reform,dc=hmcts,dc=net))";
+    private static final String REPLICATION_FILTER = "(&(objectClass=*)(domain-name=dc=reform,dc=hmcts,dc=net)(!(cn=Changelog*)))";
     private static final String NORMAL_STATUS = "normal";
 
     private final LdapTemplate ldapTemplate;
@@ -68,9 +68,6 @@ public class LdapReplicationHealthProbe implements HealthProbe {
 
             boolean result = true;
             for (ReplicationInfo record : replicationDataList) {
-                if (record.changelog) {
-                    continue;
-                }
 
                 if (record.recordType == ReplicationRecordType.LOCAL_DS) {
 
@@ -198,9 +195,7 @@ public class LdapReplicationHealthProbe implements HealthProbe {
             String directoryServer = null;
             for(Enumeration<String> e = dn.getAll(); e.hasMoreElements();) {
                 String value = e.nextElement();
-                if (value.startsWith("cn=Changelog")) {
-                    changelog = true;
-                } else if (value.startsWith("cn=Connected replication server")) {
+                if (value.startsWith("cn=Connected replication server")) {
                     connectedReplicationServer = value.split("\\) ")[1];
                 } else if (value.startsWith("cn=Connected directory server")) {
                     connectedDirectoryServer = value.split("\\) ")[1];

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbe.java
@@ -92,6 +92,7 @@ public class LdapReplicationHealthProbe implements HealthProbe {
                     case LOCAL_RS:
                         if (changesAreMissing(record)) {
                             log.error(TAG + record.recordType + " Failing missing changes check, " + record.toString());
+                            result = false;
                         } else if (log.isInfoEnabled()) {
                             log.info(TAG + record.recordType + " okay, " + record.toString());
                         }
@@ -139,8 +140,7 @@ public class LdapReplicationHealthProbe implements HealthProbe {
     }
 
     private boolean changesAreMissing(ReplicationInfo record) {
-        return (record.missingChanges < 0) ||
-                (record.missingChanges <= this.ldapProperties.getReplication().getMissingUpdatesThreshold());
+        return (record.missingChanges > this.ldapProperties.getReplication().getMissingUpdatesThreshold());
     }
 
     @EqualsAndHashCode

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/props/ConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/props/ConfigProperties.java
@@ -18,8 +18,10 @@ public class ConfigProperties {
         @Getter
         @Setter
         public static class Replication {
-            private Integer missingChangesThreshold;
-            private Integer pendingUpdatesThreshold;
+            // private Integer missingChangesThreshold;
+            // private Integer pendingUpdatesThreshold;
+            private Integer approximateDelayThreshold;
+            private Integer missingUpdatesThreshold;
         }
 
         private String root;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,8 +39,10 @@ ldap:
   root: ldaps://dummy:1639
   principal: CN=Directory Manager
   replication:
-    missing-changes-threshold: 10
-    pending-updates-threshold: 10
+    # missing-changes-threshold: 10
+    # pending-updates-threshold: 10
+    missing-updates-threshold: 999
+    approximate-delay-threshold: 120000
 
 userstore:
   healthprobe:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,8 +39,6 @@ ldap:
   root: ldaps://dummy:1639
   principal: CN=Directory Manager
   replication:
-    # missing-changes-threshold: 10
-    # pending-updates-threshold: 10
     missing-updates-threshold: 999
     approximate-delay-threshold: 120000
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,6 +2,7 @@
 <configuration>
 
     <logger name="uk.gov.hmcts.reform.idam.health" level="WARN"/>
+    <logger name="uk.gov.hmcts.reform.idam.health.ldap" level="INFO"/>
 
     <springProfile name="live">
 

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/ldap/LdapReplicationHealthProbeTest.java
@@ -17,6 +17,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.idam.health.ldap.LdapReplicationHealthProbe.ReplicationRecordType.LOCAL_DS;
+import static uk.gov.hmcts.reform.idam.health.ldap.LdapReplicationHealthProbe.ReplicationRecordType.LOCAL_RS_CONN_DS;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LdapReplicationHealthProbeTest {
@@ -35,8 +37,10 @@ public class LdapReplicationHealthProbeTest {
     @Before
     public void setup() {
         when(configProperties.getLdap()).thenReturn(ldapProperties);
-        when(ldapProperties.getReplication().getMissingChangesThreshold()).thenReturn(0);
-        when(ldapProperties.getReplication().getPendingUpdatesThreshold()).thenReturn(0);
+        //when(ldapProperties.getReplication().getMissingChangesThreshold()).thenReturn(0);
+        //when(ldapProperties.getReplication().getPendingUpdatesThreshold()).thenReturn(0);
+        when(ldapProperties.getReplication().getMissingUpdatesThreshold()).thenReturn(0);
+        when(ldapProperties.getReplication().getApproximateDelayThreshold()).thenReturn(0);
         probe = new LdapReplicationHealthProbe(ldapTemplate, configProperties);
     }
 
@@ -46,7 +50,7 @@ public class LdapReplicationHealthProbeTest {
         searchResult.add(replicationInfo("normal", 0, 0));
         searchResult.add(replicationInfo("normal", 0, 0));
 
-        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationAttributeMapper.class))).thenReturn(searchResult);
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
         assertThat(probe.probe(), is(true));
     }
 
@@ -56,7 +60,7 @@ public class LdapReplicationHealthProbeTest {
         searchResult.add(replicationInfo("unexpected", 0, 0));
         searchResult.add(replicationInfo("normal", 0, 0));
 
-        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationAttributeMapper.class))).thenReturn(searchResult);
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
         assertThat(probe.probe(), is(true));
     }
 
@@ -66,27 +70,87 @@ public class LdapReplicationHealthProbeTest {
         searchResult.add(replicationInfo("unexpected", 0, 0));
         searchResult.add(replicationInfo("unexpected", 0, 0));
 
-        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationAttributeMapper.class))).thenReturn(searchResult);
-        assertThat(probe.probe(), is(false));
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
     }
 
     @Test
-    public void testProbe_failOneMissing() {
+    public void testProbe_successOneMissing() {
         List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
         searchResult.add(replicationInfo("normal", 1, 0));
         searchResult.add(replicationInfo("unexpected", 0, 0));
 
-        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationAttributeMapper.class))).thenReturn(searchResult);
-        assertThat(probe.probe(), is(false));
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
     }
 
     @Test
-    public void testProbe_failOnePending() {
+    public void testProbe_successOnePending() {
         List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
         searchResult.add(replicationInfo("normal", 0, 1));
         searchResult.add(replicationInfo("unexpected", 0, 0));
 
-        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationAttributeMapper.class))).thenReturn(searchResult);
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
+    }
+
+    @Test
+    public void testProbe_successLocalDSReplayUpdatesOkay() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_DS, "normal", 1000, 1000, 0));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
+    }
+
+    @Test
+    public void testProbe_failLocalDSReplayUpdatesMissing() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_DS, "normal", 1000, 1, 0));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(false));
+    }
+
+    @Test
+    public void testProbe_failLocalDSReplayUpdatesUnexpected() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_DS, "normal", 1, 1000, 0));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(false));
+    }
+
+    @Test
+    public void testProbe_successLocalDSReplayUpdatesOkayUnexpectedStatus() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_DS, "unexpected", 1000, 1000, 0));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
+    }
+
+    @Test
+    public void testProbe_successLocalRSConnDSApproximateDelayOkay() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_RS_CONN_DS, null, 1000, 1000, 0));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
+        assertThat(probe.probe(), is(true));
+    }
+
+    @Test
+    public void testProbe_failLocalRSConnDSApproximateDelayExceeded() {
+        List<LdapReplicationHealthProbe.ReplicationInfo> searchResult = new ArrayList<>();
+        searchResult.add(replicationInfo(LOCAL_RS_CONN_DS, null, 1000, 1000, 1));
+        searchResult.add(replicationInfo("unexpected", 0, 0));
+
+        when(ldapTemplate.search(any(LdapQuery.class), any(LdapReplicationHealthProbe.ReplicationContextMapper.class))).thenReturn(searchResult);
         assertThat(probe.probe(), is(false));
     }
 
@@ -95,6 +159,18 @@ public class LdapReplicationHealthProbeTest {
         info.status = status;
         info.missingChanges = missing;
         info.pendingUpdates = pending;
+        return info;
+    }
+
+    protected LdapReplicationHealthProbe.ReplicationInfo replicationInfo(LdapReplicationHealthProbe.ReplicationRecordType recordType, String status, int receivedUpdates, int replayedUpdates, int approximateDelay) {
+        LdapReplicationHealthProbe.ReplicationInfo info = new LdapReplicationHealthProbe.ReplicationInfo();
+        info.recordType = recordType;
+        info.status = status;
+        info.missingChanges = -1;
+        info.pendingUpdates = -1;
+        info.receivedUpdates = receivedUpdates;
+        info.replayedUpdates = replayedUpdates;
+        info.approximateDelay = approximateDelay;
         return info;
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SIDM-2129

Changed the replication healthprobe based on https://backstage.forgerock.com/support/tickets?id=35840.

Changes:
* Do *not* mark nodes DOWN based on the replication Status attribute as it is not reliable
* Mark nodes as DOWN if the replication approximate-delay attribute is larger than a configurable threshold (for the local Directory Server entry)
* Mark nodes as DOWN if the replication missing-changes attribute is larger than a configurable threshold (for the local Replication Server entry)
* Mark nodes as DOWN if the diff between the received-updates and replayed-updates is larger than a configurable threshold (for the local Directory Server entry)
* Log interesting replication attributes for monitoring purposes