### PR TITLE
SIDM-2673: [Fix] Profile for replicationless clusters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 
 group = 'uk.gov.hmcts.reform'
-version = '1.4'
+version = '1.4.1'
 sourceCompatibility = 1.8
 
 repositories {

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/tokenstore/TokenStoreSearchHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/tokenstore/TokenStoreSearchHealthProbe.java
@@ -17,7 +17,7 @@ public class TokenStoreSearchHealthProbe implements HealthProbe {
 
     private final String TAG = "TokenStore Search: ";
 
-    private static final String LDAP_SEARCH_IN_REPLICATION = "cn=Replication,cn=monitor";
+    private static final String LDAP_SEARCH_IN_CONFIG = "cn=schema providers,cn=config";
     private static final String LDAP_SEARCH_ANY_OBJECT = "(objectClass=*)";
     private static final String LDAP_CN_ATTRIBUTE = "cn";
 
@@ -31,7 +31,7 @@ public class TokenStoreSearchHealthProbe implements HealthProbe {
     public boolean probe() {
         try {
             List<Object> searchResponse = ldapTemplate.search(
-                    LDAP_SEARCH_IN_REPLICATION,
+                    LDAP_SEARCH_IN_CONFIG,
                     LDAP_SEARCH_ANY_OBJECT,
                     SearchControls.SUBTREE_SCOPE,
                     (AttributesMapper<Object>) attrs -> attrs.get(LDAP_CN_ATTRIBUTE).get());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-2673


### Change description ###
We are currently doing a basic "is an expected ldap value there?" check for Tokenstore. However, this is looking for `cn=Replication` which does not exist in a "replicationless" cluster.
This PR changes the basic check to look for an LDAP schema config value.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
