### PR TITLE
feat(sidm-3921-ldap): IdmPingHealthProbe: add ldap check

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Details can include information on why something is DOWN and the current healthc
 **External Infrastructure Dependencies**
 
 * KeyVault secrets
+  * openidm-username
+    * used for idm ldap connectivity check
+  * openidm-password
+    * used for idm ldap connectivity check
   * test-owner-username
   * test-owner-password
   * web-admin-client-secret
@@ -245,6 +249,8 @@ Health check description of annonymous ping status for ForgeRock IDM. This probe
 
 * Request `isAlive.jsp`.
 * Assert the response contains `Server is ALIVE.`.
+* Request `/openidm/config/provisioner.openicf/ldap?_fields=enabled`
+* Assert the response contains `enabled: true` assuring IDM is connected to LDAP
 
 **Probe Configuration**
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 
 group = 'uk.gov.hmcts.reform'
-version = '2.0.3'
+version = '2.1.0'
 sourceCompatibility = 1.8
 
 repositories {

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmHealthProbeProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmHealthProbeProperties.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.health.idm;
 
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,4 +20,13 @@ public class IdmHealthProbeProperties {
     }
 
     private IdmHealthProbeProperties.Probe ping;
+
+    @Data
+    static class LdapCheck {
+        private Boolean enabled;
+        private String username;
+        private String password;
+    }
+
+    private IdmHealthProbeProperties.LdapCheck ldapCheck;
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbe.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbe.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.idam.health.idm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.idam.health.probe.HealthProbe;
@@ -19,31 +20,85 @@ public class IdmPingHealthProbe extends HealthProbe {
     private static final String STATE = "state";
     private static final String IDM_ACTIVE = "ACTIVE_READY";
 
+    private static final String LDAP_CHECK_ENABLED_FIELD = "enabled";
+
     private static String ANONYMOUS_USER = "anonymous";
     private static String ANONYMOUS_PASSWORD = "anonymous";
 
     private final IdmProvider idmProvider;
     private final String authorization;
+    private final String ldapCheckAuthorization;
+    private final IdmHealthProbeProperties idmHealthProbeProperties;
 
-    public IdmPingHealthProbe(IdmProvider idmProvider) {
+    public IdmPingHealthProbe(IdmProvider idmProvider, IdmHealthProbeProperties idmHealthProbeProperties) {
         this.idmProvider = idmProvider;
         this.authorization = "Basic " + encode(ANONYMOUS_USER, ANONYMOUS_PASSWORD);
+
+        final String ldapCheckUsername = StringUtils.defaultString(idmHealthProbeProperties.getLdapCheck().getUsername(), "");
+        final String ldapCheckPassword = StringUtils.defaultString(idmHealthProbeProperties.getLdapCheck().getPassword(), "");
+        this.ldapCheckAuthorization = "Basic " + encode(ldapCheckUsername, ldapCheckPassword);
+
+        this.idmHealthProbeProperties = idmHealthProbeProperties;
     }
 
+    /**
+     * @should pass when ping and ldap are ok
+     * @should fail when ping state is unexpected
+     * @should fail when ping state is missing
+     * @should fail when ping response is empty
+     * @should fail when ping response is null
+     * @should fail when ping throws exception
+     * @should fail when ldap enabled is false
+     * @should fail when ldap enabled is unexpected
+     * @should fail when ldap enabled is missing
+     * @should fail when ldap response is empty
+     * @should fail when ldap response is null
+     * @should fail when ldap throws exception
+     * @should pass when ping is ok and ldap check if configured to skip
+     * @should fail if ldap check is missing credentials
+     */
     @Override
     public boolean probe() {
         try {
-            Map<String, String> pingResponse = idmProvider.ping(authorization);
-            if (IDM_ACTIVE.equals(MapUtils.getString(pingResponse, STATE))) {
-                log.info(TAG + "success");
-                return true;
-            } else {
-                log.error(TAG + "response did not contain expected value");
+            final Map<String, String> pingResponse = idmProvider.ping(authorization);
+            final boolean pingOk = IDM_ACTIVE.equals(MapUtils.getString(pingResponse, STATE));
+
+            if (!pingOk) {
+                log.error(TAG + "idm ping response did not contain expected value");
+                return false;
             }
+
+            boolean checkLdap = idmHealthProbeProperties.getLdapCheck().getEnabled();
+
+            if (!checkLdap) {
+                log.info(TAG + "idm ping success, skipping ldap check, disabled per configuration");
+                return true;
+            }
+
+            log.info(TAG + "idm ping success, checking if ldap connection is enabled");
+
+            final String ldapCheckUsername = idmHealthProbeProperties.getLdapCheck().getUsername();
+            final String ldapCheckPassword = idmHealthProbeProperties.getLdapCheck().getPassword();
+            if (ldapCheckUsername == null && ldapCheckPassword == null) {
+                throw new RuntimeException("IDM ldap check is enabled but has no credentials set");
+            }
+
+            final Map<String, Object> ldapResponse = idmProvider.checkLdap(ldapCheckAuthorization, LDAP_CHECK_ENABLED_FIELD);
+            final Boolean ldapOk = MapUtils.getBoolean(ldapResponse, LDAP_CHECK_ENABLED_FIELD, false);
+
+            if (!ldapOk) {
+                log.error(TAG + "idm ldap response did not contain expected value");
+                return false;
+            }
+
+            log.info(TAG + "idm success, ping and ldap ok");
+
         } catch (Exception e) {
             log.error(TAG +  e.getMessage() + " [" + e.getClass().getSimpleName() + "]");
+            return false;
         }
-        return false;
+
+        return true;
     }
 
     private String encode(String identity, String secret) {

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/idm/IdmProvider.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.idam.health.idm;
 
+import feign.RequestLine;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
@@ -11,8 +13,10 @@ import java.util.Map;
 @Profile("idm")
 public interface IdmProvider {
 
-    @GetMapping(
-            value = "/info/ping"
-    )
+    @GetMapping("/info/ping")
     Map<String, String> ping(@RequestHeader("Authorization") String basicAuth);
+
+    @GetMapping("/config/provisioner.openicf/ldap?_fields={fields}")
+    Map<String, Object> checkLdap(@RequestHeader("Authorization") String basicAuth,
+                                  @RequestParam(value = "fields", required = true) String fields);
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/vault/VaultEnvironmentPostProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/vault/VaultEnvironmentPostProcessor.java
@@ -28,6 +28,8 @@ public class VaultEnvironmentPostProcessor implements EnvironmentPostProcessor {
     protected static final String VAULT_PROPERTIES = "vaultProperties";
 
     private static final Map<String, String> vaultKeyPropertyNames = ImmutableMap.<String, String>builder()
+            .put("openidm-username", "idm.healthprobe.ldapCheck.username")
+            .put("openidm-password", "idm.healthprobe.ldapCheck.password")
             .put("test-owner-username", "test.owner.username")
             .put("test-owner-password", "test.owner.password")
             .put("web-admin-client-secret", "web.admin.client.secret")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,8 +75,8 @@ idm:
       check-interval: 1000
     ldapCheck:
       enabled: true
-      username: idmadmin
-      password: supersecretpassword
+      username: username-from-vault
+      password: password-from-vault
 
 am:
   root: https://dummy

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,10 @@ idm:
     ping:
       freshness-interval: 6000
       check-interval: 1000
+    ldapCheck:
+      enabled: true
+      username: idmadmin
+      password: supersecretpassword
 
 am:
   root: https://dummy

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbeTest.java
@@ -188,7 +188,7 @@ public class IdmPingHealthProbeTest {
         when(this.idmHealthProbeProperties.getLdapCheck().getPassword()).thenReturn(null);
 
         when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
-        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("enabled", true));
+        
         assertThat(probe.probe(), is(false));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/idm/IdmPingHealthProbeTest.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.idam.health.idm;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -14,6 +16,8 @@ import java.util.HashMap;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -22,43 +26,169 @@ public class IdmPingHealthProbeTest {
     @Mock
     private IdmProvider idmProvider;
 
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private IdmHealthProbeProperties idmHealthProbeProperties;
+
     @InjectMocks
     private IdmPingHealthProbe probe;
 
+    @Before
+    public void idmHealthProbePropertiesSetup() {
+        when(this.idmHealthProbeProperties.getLdapCheck().getEnabled()).thenReturn(true);
+        when(this.idmHealthProbeProperties.getLdapCheck().getUsername()).thenReturn("username");
+        when(this.idmHealthProbeProperties.getLdapCheck().getPassword()).thenReturn("password");
+    }
+
+    /**
+     * @verifies pass when ping and ldap are ok
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_success() {
+    public void probe_shouldPassWhenPingAndLdapAreOk() {
         when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("enabled", true));
         assertThat(probe.probe(), is(true));
     }
 
+    /**
+     * @verifies fail when ping state is unexpected
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_failUnexpectedState() {
+    public void probe_shouldFailWhenPingStateIsUnexpected() {
         when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "UNEXPECTED"));
         assertThat(probe.probe(), is(false));
     }
 
+    /**
+     * @verifies fail when ping state is missing
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_failMissingState() {
+    public void probe_shouldFailWhenPingStateIsMissing() {
         when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("unexpected", "UNEXPECTED"));
         assertThat(probe.probe(), is(false));
     }
 
+    /**
+     * @verifies fail when ping response is empty
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_failEmptyResponse() {
+    public void probe_shouldFailWhenPingResponseIsEmpty() {
         when(idmProvider.ping(anyString())).thenReturn(new HashMap<>());
         assertThat(probe.probe(), is(false));
     }
 
+    /**
+     * @verifies fail when ping response is null
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_failNullResponse() {
+    public void probe_shouldFailWhenPingResponseIsNull() {
         when(idmProvider.ping(anyString())).thenReturn(null);
         assertThat(probe.probe(), is(false));
     }
 
+    /**
+     * @verifies fail when ping throws exception
+     * @see IdmPingHealthProbe#probe()
+     */
     @Test
-    public void testProbe_failException() {
+    public void probe_shouldFailWhenPingThrowsException() {
         when(idmProvider.ping(anyString())).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         assertThat(probe.probe(), is(false));
     }
 
+    /**
+     * @verifies fail when ldap enabled is false
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapEnabledIsFalse() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("enabled", false));
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies fail when ldap enabled is unexpected
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapEnabledIsUnexpected() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("enabled", "UNEXPECTED"));
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies fail when ldap enabled is missing
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapEnabledIsMissing() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("unexpected", "UNEXPECTED"));
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies fail when ldap response is empty
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapResponseIsEmpty() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(new HashMap<>());
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies fail when ldap response is null
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapResponseIsNull() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(null);
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies fail when ldap throws exception
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailWhenLdapThrowsException() {
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+        assertThat(probe.probe(), is(false));
+    }
+
+    /**
+     * @verifies pass when ping is ok and ldap check if configured to skip
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldPassWhenPingIsOkAndLdapCheckIfConfiguredToSkip() throws Exception {
+        when(this.idmHealthProbeProperties.getLdapCheck().getEnabled()).thenReturn(false);
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        assertThat(probe.probe(), is(true));
+        verify(idmProvider, never()).checkLdap(anyString(), anyString());
+    }
+
+    /**
+     * @verifies fail if ldap check is missing credentials
+     * @see IdmPingHealthProbe#probe()
+     */
+    @Test
+    public void probe_shouldFailIfLdapCheckIsMissingCredentials() throws Exception {
+        when(this.idmHealthProbeProperties.getLdapCheck().getUsername()).thenReturn(null);
+        when(this.idmHealthProbeProperties.getLdapCheck().getPassword()).thenReturn(null);
+
+        when(idmProvider.ping(anyString())).thenReturn(ImmutableMap.of("state", "ACTIVE_READY"));
+        when(idmProvider.checkLdap(anyString(), anyString())).thenReturn(ImmutableMap.of("enabled", true));
+        assertThat(probe.probe(), is(false));
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3921


### Change description ###

**require credentials!!!**
see current solution and let me know if it needs changing

### Test results ###
Performed testing in sandbox which was initially throwing 401 and I had to fix `openidm-password` value in sandbox vault

Test strategy:
1 run healthchecker and expect status UP
2 update `/opt/idm/openidm/conf/provisioner.openicf-ldap.json` setting `enabled` to false
3 expect status DOWN
4 update `/opt/idm/openidm/conf/provisioner.openicf-ldap.json` setting `enabled` to false
5 expect status UP

Results:
```
2020-03-17 14:29:16,957 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:16,975 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
2020-03-17 14:29:21,997 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:22,009 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
2020-03-17 14:29:27,027 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:27,042 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:27,042 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.probe.ScheduledHealthProbeIndicator: IdmPingHealthProbe: Status changing from UP to DOWN
2020-03-17 14:29:28,059 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:28,078 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:29,098 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:29,110 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:30,146 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:30,174 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:31,194 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:31,213 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:32,233 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:32,250 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:33,268 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:33,288 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:34,311 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:34,325 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:35,340 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:35,351 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:36,366 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:36,378 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:37,405 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:37,417 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:38,432 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:38,444 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:39,459 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:39,473 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:40,489 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:40,504 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:41,522 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:41,536 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:42,577 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:42,589 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:43,603 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:43,616 ERROR [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ldap response did not contain expected value
2020-03-17 14:29:44,632 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:44,644 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
2020-03-17 14:29:44,644 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.probe.ScheduledHealthProbeIndicator: IdmPingHealthProbe: Status changing from DOWN to UP
2020-03-17 14:29:49,679 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:49,700 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
2020-03-17 14:29:54,725 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:54,744 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
2020-03-17 14:29:59,767 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm ping success, checking if ldap connection is enabled
2020-03-17 14:29:59,784 INFO  [ProbeScheduler4] uk.gov.hmcts.reform.idam.health.idm.IdmPingHealthProbe: IDM Ping: idm success, ping and ldap ok
```