### PR TITLE
SIDM-6009: Increase the freshness interval of the isAlive probe 

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,7 +96,7 @@ am:
   root: https://dummy
   healthprobe:
     isAlive:
-      freshness-interval: 6000
+      freshness-interval: 30000
       check-interval: 1000
     passwordGrant:
       freshness-interval: 360000


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Set the freshness-interval of the AM isAlive health probe to 30 seconds. This is in line with the standard timeout interval used across infrastructure components and means that we can tolerate AM slowness/unresponsiveness for up to 30 seconds. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
