### PR TITLE
SIDM-6009: Tune HC probes  freshness intervals

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
@@ -56,7 +56,7 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator {
 
     protected void refresh() {
         boolean probeHasExpired = status == Status.UNKNOWN || LocalDateTime.now(clock)
-                .isAfter(statusDateTime.plus(Math.round(0.75 * freshnessInterval), ChronoUnit.MILLIS));
+                .isAfter(statusDateTime.plus(Math.round(0.5 * freshnessInterval), ChronoUnit.MILLIS));
         if (status == Status.UP && !probeHasExpired) {
             return;
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,7 +54,7 @@ ldap:
 userstore:
   healthprobe:
     authentication:
-      freshness-interval: 6000
+      freshness-interval: 60000
       check-interval: 1000
     replication:
       freshness-interval: 60000
@@ -69,7 +69,7 @@ userstore:
 tokenstore:
   healthprobe:
     search:
-      freshness-interval: 6000
+      freshness-interval: 60000
       check-interval: 1000
     replication:
       freshness-interval: 60000
@@ -85,7 +85,7 @@ idm:
   root: https://dummy
   healthprobe:
     ping:
-      freshness-interval: 6000
+      freshness-interval: 30000
       check-interval: 1000
     ldapCheck:
       enabled: true


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-6009


### Change description ###
* Tune health probes freshness intervals.
* Allow probes to refresh hafway  through  their freshness intervals.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
