### PR TITLE
Add timestamps to component health probe details

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ the probes and their statuses. For example:
 {"status":"UP","components":{"amLiveScheduledHealthProbe":{"status":"UP"},"amPasswordGrantScheduledHealthProbe":{"status":"UP"},"amReadyScheduledHealthProbe":{"status":"UP"}}}
 ```
 
+Scheduled probe components include timestamp metadata in their `details` object after a scheduled probe
+has completed. The existing probe-specific detail key is preserved when an error detail exists.
+
+Example component response:
+
+```
+{
+  "status": "DOWN",
+  "details": {
+    "AmLiveHealthProbe": "Unexpected response: 503",
+    "lastChecked": "2026-05-14T10:30:00Z",
+    "lastStatusChange": "2026-05-14T10:30:00Z",
+    "lastDetailUpdate": "2026-05-14T10:30:00Z"
+  }
+}
+```
+
+Timestamp meanings:
+
+| Field            | Meaning                                                                                          |
+|------------------|--------------------------------------------------------------------------------------------------|
+| lastChecked      | The last time the scheduled probe completed and recorded a result.                               |
+| lastStatusChange | The last time the current component status was first observed or later changed.                  |
+| lastDetailUpdate | The last time the currently displayed detail text was recorded.                                   |
+
+`lastDetailUpdate` is useful because successful probes do not clear older detail text. A component can
+therefore show status `UP` while still carrying a previous error detail; in that case `lastChecked`
+shows the latest successful check time and `lastDetailUpdate` shows when the displayed detail was
+originally recorded.
+
+For probes that remain `UNKNOWN`, `lastStatusChange` means the current `UNKNOWN` state was first
+observed at that time in the running health-checker process.
+
 ## 1.3. Statuses
 
 | Status         | Description                                                     |

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
@@ -63,7 +63,7 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
     public boolean isOkay() {
         Status status = currentObservation.status();
         if (REQUIRE_PROBE_STATES.contains(status)) {
-            return this.healthProbe.probe() || failureHandling == HealthProbeFailureHandling.IGNORE;
+            return runProbeAndRecordObservation() || failureHandling == HealthProbeFailureHandling.IGNORE;
         }
 
         if (failureHandling == HealthProbeFailureHandling.MARK_AS_DOWN) {
@@ -84,6 +84,11 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
             return;
         }
 
+        runProbeAndRecordObservation();
+    }
+
+    private boolean runProbeAndRecordObservation() {
+        Status previousStatus = currentObservation.status();
         boolean probeResult = this.healthProbe.probe();
         Instant checkedAt = clock.instant();
         String currentDetails = this.healthProbe.getDetails();
@@ -105,6 +110,7 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
         }
 
         recordObservation(newStatus, currentDetails, probeResult, checkedAt);
+        return probeResult;
     }
 
     @VisibleForTesting

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.TaskScheduler;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;
@@ -26,6 +27,9 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
 
     private Status status;
     private LocalDateTime statusDateTime;
+    private Instant lastChecked;
+    private Instant lastStatusChange;
+    private Instant lastDetailUpdate;
 
     private static final EnumSet<Status> REQUIRE_PROBE_STATES = EnumSet.of(Status.OUT_OF_SERVICE, Status.UNKNOWN);
 
@@ -65,16 +69,23 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
     }
 
     protected void refresh() {
-        boolean probeHasExpired = REQUIRE_PROBE_STATES.contains(status) || LocalDateTime.now(clock)
+        LocalDateTime now = LocalDateTime.now(clock);
+        boolean probeHasExpired = REQUIRE_PROBE_STATES.contains(status) || now
                 .isAfter(statusDateTime.plus(Math.round(0.5 * freshnessInterval.toMillis()), ChronoUnit.MILLIS));
         if (status == Status.UP && !probeHasExpired) {
             return;
         }
 
         boolean probeResult = this.healthProbe.probe();
+        Instant checkedAt = clock.instant();
+        String currentDetails = this.healthProbe.getDetails();
+
+        this.lastChecked = checkedAt;
+        updateDetailTimestamp(currentDetails, probeResult, checkedAt);
 
         if (probeResult || failureHandling == HealthProbeFailureHandling.MARK_AS_DOWN) {
             Status newStatus = probeResult ? Status.UP : Status.DOWN;
+            updateStatusTimestamp(this.status, newStatus, checkedAt);
             if (this.status != newStatus) {
                 if (Status.DOWN.equals(newStatus)) {
                     log.error("{}: Status changing from {} to {}", this.healthProbe.getName(), this.status, newStatus);
@@ -84,8 +95,9 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
             }
 
             this.status = newStatus;
-            this.statusDateTime = LocalDateTime.now(clock);
+            this.statusDateTime = LocalDateTime.ofInstant(checkedAt, clock.getZone());
         } else {
+            updateStatusTimestamp(this.status, this.status, checkedAt);
             log.warn("{}: probe failed, status {} unchanged", this.healthProbe.getName(), this.status);
         }
     }
@@ -100,6 +112,20 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
         this.status = status;
     }
 
+    private void updateDetailTimestamp(String currentDetails, boolean probeResult, Instant checkedAt) {
+        if (currentDetails == null) {
+            this.lastDetailUpdate = null;
+        } else if (!probeResult) {
+            this.lastDetailUpdate = checkedAt;
+        }
+    }
+
+    private void updateStatusTimestamp(Status previousStatus, Status currentStatus, Instant checkedAt) {
+        if (lastStatusChange == null || previousStatus != currentStatus) {
+            this.lastStatusChange = checkedAt;
+        }
+    }
+
     @Override
     public Health health() {
         Health.Builder builder;
@@ -112,9 +138,19 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
         } else {
             builder = Health.down();
         }
-        if (healthProbe.getDetails() != null) {
-            builder.withDetail(healthProbe.getName(), healthProbe.getDetails());
+        String details = healthProbe.getDetails();
+        if (details != null) {
+            builder.withDetail(healthProbe.getName(), details);
         }
+        addTimestampDetail(builder, "lastChecked", lastChecked);
+        addTimestampDetail(builder, "lastStatusChange", lastStatusChange);
+        addTimestampDetail(builder, "lastDetailUpdate", lastDetailUpdate);
         return builder.build();
+    }
+
+    private void addTimestampDetail(Health.Builder builder, String name, Instant timestamp) {
+        if (timestamp != null) {
+            builder.withDetail(name, timestamp.toString());
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java
@@ -25,13 +25,18 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
     private final Duration checkInterval;
     private Clock clock;
 
-    private Status status;
     private LocalDateTime statusDateTime;
-    private Instant lastChecked;
-    private Instant lastStatusChange;
-    private Instant lastDetailUpdate;
+    private ProbeObservation currentObservation;
 
     private static final EnumSet<Status> REQUIRE_PROBE_STATES = EnumSet.of(Status.OUT_OF_SERVICE, Status.UNKNOWN);
+
+    private record ProbeObservation(
+            Status status,
+            String details,
+            Instant lastChecked,
+            Instant lastStatusChange,
+            Instant lastDetailUpdate) {
+    }
 
     public ScheduledHealthProbeIndicator(
             HealthProbe healthProbe,
@@ -44,7 +49,8 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
         this.taskScheduler = taskScheduler;
         this.freshnessInterval = freshnessInterval;
         this.checkInterval = checkInterval;
-        this.status = failureHandling == HealthProbeFailureHandling.IGNORE ? Status.UNKNOWN: Status.OUT_OF_SERVICE;
+        Status initialStatus = failureHandling == HealthProbeFailureHandling.IGNORE ? Status.UNKNOWN: Status.OUT_OF_SERVICE;
+        this.currentObservation = new ProbeObservation(initialStatus, null, null, null, null);
         this.clock = Clock.systemDefaultZone();
     }
 
@@ -55,6 +61,7 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
 
     @Override
     public boolean isOkay() {
+        Status status = currentObservation.status();
         if (REQUIRE_PROBE_STATES.contains(status)) {
             return this.healthProbe.probe() || failureHandling == HealthProbeFailureHandling.IGNORE;
         }
@@ -69,37 +76,35 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
     }
 
     protected void refresh() {
+        Status previousStatus = currentObservation.status();
         LocalDateTime now = LocalDateTime.now(clock);
-        boolean probeHasExpired = REQUIRE_PROBE_STATES.contains(status) || now
+        boolean probeHasExpired = REQUIRE_PROBE_STATES.contains(previousStatus) || statusDateTime == null || now
                 .isAfter(statusDateTime.plus(Math.round(0.5 * freshnessInterval.toMillis()), ChronoUnit.MILLIS));
-        if (status == Status.UP && !probeHasExpired) {
+        if (previousStatus == Status.UP && !probeHasExpired) {
             return;
         }
 
         boolean probeResult = this.healthProbe.probe();
         Instant checkedAt = clock.instant();
         String currentDetails = this.healthProbe.getDetails();
-
-        this.lastChecked = checkedAt;
-        updateDetailTimestamp(currentDetails, probeResult, checkedAt);
+        Status newStatus = previousStatus;
 
         if (probeResult || failureHandling == HealthProbeFailureHandling.MARK_AS_DOWN) {
-            Status newStatus = probeResult ? Status.UP : Status.DOWN;
-            updateStatusTimestamp(this.status, newStatus, checkedAt);
-            if (this.status != newStatus) {
+            newStatus = probeResult ? Status.UP : Status.DOWN;
+            if (previousStatus != newStatus) {
                 if (Status.DOWN.equals(newStatus)) {
-                    log.error("{}: Status changing from {} to {}", this.healthProbe.getName(), this.status, newStatus);
+                    log.error("{}: Status changing from {} to {}", this.healthProbe.getName(), previousStatus, newStatus);
                 } else {
-                    log.info("{}: Status changing from {} to {}", this.healthProbe.getName(), this.status, newStatus);
+                    log.info("{}: Status changing from {} to {}", this.healthProbe.getName(), previousStatus, newStatus);
                 }
             }
 
-            this.status = newStatus;
             this.statusDateTime = LocalDateTime.ofInstant(checkedAt, clock.getZone());
         } else {
-            updateStatusTimestamp(this.status, this.status, checkedAt);
-            log.warn("{}: probe failed, status {} unchanged", this.healthProbe.getName(), this.status);
+            log.warn("{}: probe failed, status {} unchanged", this.healthProbe.getName(), previousStatus);
         }
+
+        recordObservation(newStatus, currentDetails, probeResult, checkedAt);
     }
 
     @VisibleForTesting
@@ -109,42 +114,54 @@ public class ScheduledHealthProbeIndicator implements HealthProbeIndicator, Heal
 
     @VisibleForTesting
     protected void setStatus(Status status) {
-        this.status = status;
+        this.currentObservation = new ProbeObservation(
+                status,
+                currentObservation.details(),
+                currentObservation.lastChecked(),
+                currentObservation.lastStatusChange(),
+                currentObservation.lastDetailUpdate());
     }
 
-    private void updateDetailTimestamp(String currentDetails, boolean probeResult, Instant checkedAt) {
-        if (currentDetails == null) {
-            this.lastDetailUpdate = null;
+    private void recordObservation(Status status, String details, boolean probeResult, Instant checkedAt) {
+        Instant lastStatusChange = currentObservation.lastStatusChange();
+        if (lastStatusChange == null || currentObservation.status() != status) {
+            lastStatusChange = checkedAt;
+        }
+
+        Instant lastDetailUpdate = currentObservation.lastDetailUpdate();
+        if (details == null) {
+            lastDetailUpdate = null;
         } else if (!probeResult) {
-            this.lastDetailUpdate = checkedAt;
+            lastDetailUpdate = checkedAt;
         }
-    }
 
-    private void updateStatusTimestamp(Status previousStatus, Status currentStatus, Instant checkedAt) {
-        if (lastStatusChange == null || previousStatus != currentStatus) {
-            this.lastStatusChange = checkedAt;
-        }
+        this.currentObservation = new ProbeObservation(
+                status,
+                details,
+                checkedAt,
+                lastStatusChange,
+                lastDetailUpdate);
     }
 
     @Override
     public Health health() {
+        ProbeObservation observation = currentObservation;
         Health.Builder builder;
-        if (status == Status.UP) {
+        if (observation.status() == Status.UP) {
             builder = Health.up();
-        } else if (status == Status.UNKNOWN) {
+        } else if (observation.status() == Status.UNKNOWN) {
             builder = Health.unknown();
-        } else if (status == Status.OUT_OF_SERVICE) {
+        } else if (observation.status() == Status.OUT_OF_SERVICE) {
             builder = Health.outOfService();
         } else {
             builder = Health.down();
         }
-        String details = healthProbe.getDetails();
-        if (details != null) {
-            builder.withDetail(healthProbe.getName(), details);
+        if (observation.details() != null) {
+            builder.withDetail(healthProbe.getName(), observation.details());
         }
-        addTimestampDetail(builder, "lastChecked", lastChecked);
-        addTimestampDetail(builder, "lastStatusChange", lastStatusChange);
-        addTimestampDetail(builder, "lastDetailUpdate", lastDetailUpdate);
+        addTimestampDetail(builder, "lastChecked", observation.lastChecked());
+        addTimestampDetail(builder, "lastStatusChange", observation.lastStatusChange());
+        addTimestampDetail(builder, "lastDetailUpdate", observation.lastDetailUpdate());
         return builder.build();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
@@ -193,7 +193,6 @@ public class ScheduledHealthProbeIndicatorTest {
     @Test
     public void testHealth_unknown() {
         strictScheduledHealthProbe.setStatus(Status.UNKNOWN);
-        when(healthProbe.getDetails()).thenReturn(null);
         Health health = strictScheduledHealthProbe.health();
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UNKNOWN));
         assertThat(health.getDetails(), is(anEmptyMap()));
@@ -201,9 +200,12 @@ public class ScheduledHealthProbeIndicatorTest {
 
     @Test
     public void testHealth_unknownWithDetails() {
-        strictScheduledHealthProbe.setStatus(Status.UNKNOWN);
+        when(healthProbe.probe()).thenReturn(false);
         when(healthProbe.getDetails()).thenReturn("test-error");
-        Health health = strictScheduledHealthProbe.health();
+        ignoringScheduledHealthProbe.refresh();
+
+        Health health = ignoringScheduledHealthProbe.health();
+
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UNKNOWN));
         assertThat(health.getDetails().get("testprobe"), is("test-error"));
     }
@@ -211,7 +213,6 @@ public class ScheduledHealthProbeIndicatorTest {
     @Test
     public void testHealth_down() {
         strictScheduledHealthProbe.setStatus(Status.DOWN);
-        when(healthProbe.getDetails()).thenReturn(null);
         Health health = strictScheduledHealthProbe.health();
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.DOWN));
         assertThat(health.getDetails(), is(anEmptyMap()));
@@ -219,9 +220,12 @@ public class ScheduledHealthProbeIndicatorTest {
 
     @Test
     public void testHealth_downWithDetails() {
-        strictScheduledHealthProbe.setStatus(Status.DOWN);
+        when(healthProbe.probe()).thenReturn(false);
         when(healthProbe.getDetails()).thenReturn("test-error");
+        strictScheduledHealthProbe.refresh();
+
         Health health = strictScheduledHealthProbe.health();
+
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.DOWN));
         assertThat(health.getDetails().get("testprobe"), is("test-error"));
     }
@@ -229,19 +233,18 @@ public class ScheduledHealthProbeIndicatorTest {
     @Test
     public void testHealth_outOfService() {
         strictScheduledHealthProbe.setStatus(Status.OUT_OF_SERVICE);
-        when(healthProbe.getDetails()).thenReturn(null);
         Health health = strictScheduledHealthProbe.health();
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.OUT_OF_SERVICE));
         assertThat(health.getDetails(), is(anEmptyMap()));
     }
 
     @Test
-    public void testHealth_outOfServiceWithDetails() {
+    public void testHealth_outOfServiceDoesNotReadLiveProbeDetailsBeforeObservation() {
         strictScheduledHealthProbe.setStatus(Status.OUT_OF_SERVICE);
-        when(healthProbe.getDetails()).thenReturn("test-error");
         Health health = strictScheduledHealthProbe.health();
         assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.OUT_OF_SERVICE));
-        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails(), is(anEmptyMap()));
+        verify(healthProbe, never()).getDetails();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
@@ -244,4 +244,85 @@ public class ScheduledHealthProbeIndicatorTest {
         assertThat(health.getDetails().get("testprobe"), is("test-error"));
     }
 
+    @Test
+    public void testHealth_includesLastCheckedAndLastStatusChangeAfterSuccessfulRefresh() {
+        when(healthProbe.probe()).thenReturn(true);
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UP));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is(nullValue()));
+    }
+
+    @Test
+    public void testHealth_includesLastDetailUpdateWhenFailedProbeReportsDetails() {
+        when(healthProbe.probe()).thenReturn(false);
+        when(healthProbe.getDetails()).thenReturn("test-error");
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.DOWN));
+        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is("1970-01-01T01:00:00Z"));
+    }
+
+    @Test
+    public void testHealth_includesLastStatusChangeForIgnoredUnknownAfterFirstObservedRun() {
+        when(healthProbe.probe()).thenReturn(false);
+        when(healthProbe.getDetails()).thenReturn("test-error");
+        ignoringScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+        ignoringScheduledHealthProbe.refresh();
+
+        Health health = ignoringScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UNKNOWN));
+        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is("1970-01-01T01:00:00Z"));
+    }
+
+    @Test
+    public void testHealth_keepsLastDetailUpdateWhenStaleDetailRemainsAfterSuccess() {
+        when(healthProbe.probe()).thenReturn(false, true);
+        when(healthProbe.getDetails()).thenReturn("test-error");
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM + 60), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UP));
+        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:01:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:01:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is("1970-01-01T01:00:00Z"));
+    }
+
+    @Test
+    public void testHealth_updatesLastCheckedWithoutChangingLastStatusChangeWhenStatusRepeats() {
+        when(healthProbe.probe()).thenReturn(false);
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM + 60), ZoneId.systemDefault()));
+        strictScheduledHealthProbe.refresh();
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.DOWN));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:01:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java
@@ -71,7 +71,50 @@ public class ScheduledHealthProbeIndicatorTest {
     @Test
     public void testIsOkay_successBeforeRefresh() {
         when(healthProbe.probe()).thenReturn(true);
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+
         assertThat(strictScheduledHealthProbe.isOkay(), is(true));
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UP));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is(nullValue()));
+    }
+
+    @Test
+    public void testIsOkay_recordsFailedObservationBeforeRefresh() {
+        when(healthProbe.probe()).thenReturn(false);
+        when(healthProbe.getDetails()).thenReturn("test-error");
+        strictScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+
+        assertThat(strictScheduledHealthProbe.isOkay(), is(false));
+
+        Health health = strictScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.DOWN));
+        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is("1970-01-01T01:00:00Z"));
+    }
+
+    @Test
+    public void testIsOkay_recordsIgnoredUnknownObservationBeforeRefresh() {
+        when(healthProbe.probe()).thenReturn(false);
+        when(healthProbe.getDetails()).thenReturn("test-error");
+        ignoringScheduledHealthProbe.changeClock(Clock.fixed(Instant.ofEpochSecond(EPOCH_1AM), ZoneId.systemDefault()));
+
+        assertThat(ignoringScheduledHealthProbe.isOkay(), is(true));
+
+        Health health = ignoringScheduledHealthProbe.health();
+
+        assertThat(health.getStatus(), is(org.springframework.boot.actuate.health.Status.UNKNOWN));
+        assertThat(health.getDetails().get("testprobe"), is("test-error"));
+        assertThat(health.getDetails().get("lastChecked"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastStatusChange"), is("1970-01-01T01:00:00Z"));
+        assertThat(health.getDetails().get("lastDetailUpdate"), is("1970-01-01T01:00:00Z"));
     }
 
     @Test
@@ -143,7 +186,7 @@ public class ScheduledHealthProbeIndicatorTest {
         assertThat(ignoringScheduledHealthProbe.isOkay(), is(true));
         ignoringScheduledHealthProbe.refresh();
         assertThat(ignoringScheduledHealthProbe.isOkay(), is(true));
-        verify(healthProbe, times(3)).probe();
+        verify(healthProbe, times(2)).probe();
     }
 
     @Test
@@ -154,7 +197,7 @@ public class ScheduledHealthProbeIndicatorTest {
         assertThat(ignoringOnceReadyScheduledHealthProbe.isOkay(), is(true));
         ignoringOnceReadyScheduledHealthProbe.refresh();
         assertThat(ignoringOnceReadyScheduledHealthProbe.isOkay(), is(true));
-        verify(healthProbe, times(3)).probe();
+        verify(healthProbe, times(2)).probe();
     }
 
     @Test


### PR DESCRIPTION
Jira link
https://tools.hmcts.net/jira/browse/SIDM-10356

Change description

`src/main/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicator.java`
- Added `lastChecked`, `lastStatusChange`, and `lastDetailUpdate` to scheduled probe health details.
- Refactored observation handling so status, detail text, and timestamps are recorded together in a single stored observation.
- `health()` now renders from the stored observation instead of reading live probe details directly.
- Preserved the existing probe detail key and top-level health status behaviour.
- Ensured ignored probes that remain `UNKNOWN` also carry `lastStatusChange`.

`src/test/java/uk/gov/hmcts/reform/idam/health/probe/ScheduledHealthProbeIndicatorTest.java`
- Added and updated coverage for successful, failed, ignored `UNKNOWN`, stale-detail-after-recovery, and repeated same-status observations.
- Added coverage that `health()` does not read live probe details before an observation exists.

`README.md`
- Documented the timestamp fields and how to interpret stale retained detail in `/admin/health`.

Testing
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew clean test bootJar`