### PR TITLE
Sidm 10355 replicationmonitor health probe reporting unknown

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverter.java
@@ -56,7 +56,7 @@ public class ReplicationStatusConverter {
     private ReplicationInfo simpleConvert(String value, String context) {
         try {
             String[] parts = value.split("\\s+");
-            if (parts.length == 6) {
+            if (parts.length == 6 || parts.length == 7) {
                 ReplicationInfo info = new ReplicationInfo();
                 info.setInstance(parts[1]);
                 info.setStatus(parts[2]);

--- a/src/main/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverter.java
@@ -56,7 +56,7 @@ public class ReplicationStatusConverter {
     private ReplicationInfo simpleConvert(String value, String context) {
         try {
             String[] parts = value.split("\\s+");
-            if (parts.length == 6 || parts.length == 7) {
+            if (parts.length == 7) {
                 ReplicationInfo info = new ReplicationInfo();
                 info.setInstance(parts[1]);
                 info.setStatus(parts[2]);

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
@@ -37,11 +37,11 @@ public class ReplicationStatusConverterTest {
         textOutput.add("line2");
         textOutput.add("line3");
         textOutput.add("dc=test-context");
-        textOutput.add("├ test-identity test-status 1 2 3");
-        textOutput.add("└ test-other-identity test-other-status 4 5 6");
+        textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status 4 5 6 test-other-hostname");
         textOutput.add("ou=test-other-context");
-        textOutput.add("├ test-identity test-status 9 8 7");
-        textOutput.add("└ test-other-identity test-other-status 6 5 4");
+        textOutput.add("├ test-identity test-status 9 8 7 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status 6 5 4 test-other-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(2));
@@ -83,8 +83,8 @@ public class ReplicationStatusConverterTest {
         textOutput.add("line3");
         textOutput.add("dc=test-context");
         textOutput.add("├ fail");
-        textOutput.add("├ test-identity test-status 1 2 3");
-        textOutput.add("└ test-other-identity test-other-status fail 5 6");
+        textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status fail 5 6 test-other-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(1));
@@ -96,6 +96,32 @@ public class ReplicationStatusConverterTest {
         assertThat(results.get(0).getReceiveDelayMs(), is (1L));
         assertThat(results.get(0).getReplayDelayMs(), is(2L));
         assertThat(results.get(0).getEntryCount(), is(3L));
+    }
+
+    @Test
+    public void convert_withDs8HostnameColumn() {
+        when(probeProperties.getCommand().getReplicationIdentity()).thenReturn("forgerock_ds_tokenstore_idam_sandbox_2");
+        List<String> textOutput = new ArrayList<>();
+        textOutput.add("Base DN / DS                                  Status  Receive     Replay      Entry count  Hostname");
+        textOutput.add("                                                      delay (ms)  delay (ms)");
+        textOutput.add("----------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        textOutput.add("ou=tokens");
+        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_1  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-1.service.core-compute-idam-sandbox.internal");
+        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_2  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-2.service.core-compute-idam-sandbox.internal");
+        textOutput.add("└─ DS/forgerock_ds_tokenstore_idam_sandbox_3  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-3.service.core-compute-idam-sandbox.internal");
+        TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
+
+        ReplicationStatus status = replicationStatusConverter.convert(response);
+
+        assertThat(status.getContextReplicationInfo().size(), is(1));
+        List<ReplicationInfo> results = status.getContextReplicationInfo().get("ou=tokens");
+        assertThat(results.size(), is(3));
+        assertThat(results.get(1).getInstance(), is("DS/forgerock_ds_tokenstore_idam_sandbox_2"));
+        assertThat(results.get(1).getInstanceType(), is(InstanceType.PRIMARY));
+        assertThat(results.get(1).getStatus(), is("GOOD"));
+        assertThat(results.get(1).getReceiveDelayMs(), is(0L));
+        assertThat(results.get(1).getReplayDelayMs(), is(0L));
+        assertThat(results.get(1).getEntryCount(), is(3038L));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
@@ -38,10 +38,10 @@ public class ReplicationStatusConverterTest {
         textOutput.add("line3");
         textOutput.add("dc=test-context");
         textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status 4 5 6 test-other-hostname");
+        textOutput.add("└ test-other-identity test-other-status 4 5 6 test-hostname");
         textOutput.add("ou=test-other-context");
         textOutput.add("├ test-identity test-status 9 8 7 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status 6 5 4 test-other-hostname");
+        textOutput.add("└ test-other-identity test-other-status 6 5 4 test-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(2));
@@ -84,7 +84,7 @@ public class ReplicationStatusConverterTest {
         textOutput.add("dc=test-context");
         textOutput.add("├ fail");
         textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status fail 5 6 test-other-hostname");
+        textOutput.add("└ test-other-identity test-other-status fail 5 6 test-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(1));

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
@@ -38,10 +38,10 @@ public class ReplicationStatusConverterTest {
         textOutput.add("line3");
         textOutput.add("dc=test-context");
         textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status 4 5 6 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status 4 5 6 test-other-hostname");
         textOutput.add("ou=test-other-context");
         textOutput.add("├ test-identity test-status 9 8 7 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status 6 5 4 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status 6 5 4 test-other-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(2));
@@ -84,7 +84,7 @@ public class ReplicationStatusConverterTest {
         textOutput.add("dc=test-context");
         textOutput.add("├ fail");
         textOutput.add("├ test-identity test-status 1 2 3 test-hostname");
-        textOutput.add("└ test-other-identity test-other-status fail 5 6 test-hostname");
+        textOutput.add("└ test-other-identity test-other-status fail 5 6 test-other-hostname");
         TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
         ReplicationStatus status = replicationStatusConverter.convert(response);
         assertThat(status.getContextReplicationInfo().size(), is(1));

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
@@ -99,6 +99,32 @@ public class ReplicationStatusConverterTest {
     }
 
     @Test
+    public void convert_withDs8HostnameColumn() {
+        when(probeProperties.getCommand().getReplicationIdentity()).thenReturn("forgerock_ds_tokenstore_idam_sandbox_2");
+        List<String> textOutput = new ArrayList<>();
+        textOutput.add("Base DN / DS                                  Status  Receive     Replay      Entry count  Hostname");
+        textOutput.add("                                                      delay (ms)  delay (ms)");
+        textOutput.add("----------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+        textOutput.add("ou=tokens");
+        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_1  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-1.service.core-compute-idam-sandbox.internal");
+        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_2  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-2.service.core-compute-idam-sandbox.internal");
+        textOutput.add("└─ DS/forgerock_ds_tokenstore_idam_sandbox_3  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-3.service.core-compute-idam-sandbox.internal");
+        TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
+
+        ReplicationStatus status = replicationStatusConverter.convert(response);
+
+        assertThat(status.getContextReplicationInfo().size(), is(1));
+        List<ReplicationInfo> results = status.getContextReplicationInfo().get("ou=tokens");
+        assertThat(results.size(), is(3));
+        assertThat(results.get(1).getInstance(), is("DS/forgerock_ds_tokenstore_idam_sandbox_2"));
+        assertThat(results.get(1).getInstanceType(), is(InstanceType.PRIMARY));
+        assertThat(results.get(1).getStatus(), is("GOOD"));
+        assertThat(results.get(1).getReceiveDelayMs(), is(0L));
+        assertThat(results.get(1).getReplayDelayMs(), is(0L));
+        assertThat(results.get(1).getEntryCount(), is(3038L));
+    }
+
+    @Test
     public void convert_withErrors() {
         TextCommandRunner.Response response = new TextCommandRunner.Response(Collections.emptyList(), Collections.singletonList("test-error"));
         ReplicationStatus status = replicationStatusConverter.convert(response);

--- a/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java
@@ -99,32 +99,6 @@ public class ReplicationStatusConverterTest {
     }
 
     @Test
-    public void convert_withDs8HostnameColumn() {
-        when(probeProperties.getCommand().getReplicationIdentity()).thenReturn("forgerock_ds_tokenstore_idam_sandbox_2");
-        List<String> textOutput = new ArrayList<>();
-        textOutput.add("Base DN / DS                                  Status  Receive     Replay      Entry count  Hostname");
-        textOutput.add("                                                      delay (ms)  delay (ms)");
-        textOutput.add("----------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
-        textOutput.add("ou=tokens");
-        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_1  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-1.service.core-compute-idam-sandbox.internal");
-        textOutput.add("├─ DS/forgerock_ds_tokenstore_idam_sandbox_2  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-2.service.core-compute-idam-sandbox.internal");
-        textOutput.add("└─ DS/forgerock_ds_tokenstore_idam_sandbox_3  GOOD             0           0         3038  forgerock-ds-tokenstore-idam-sandbox-3.service.core-compute-idam-sandbox.internal");
-        TextCommandRunner.Response response = new TextCommandRunner.Response(textOutput, Collections.emptyList());
-
-        ReplicationStatus status = replicationStatusConverter.convert(response);
-
-        assertThat(status.getContextReplicationInfo().size(), is(1));
-        List<ReplicationInfo> results = status.getContextReplicationInfo().get("ou=tokens");
-        assertThat(results.size(), is(3));
-        assertThat(results.get(1).getInstance(), is("DS/forgerock_ds_tokenstore_idam_sandbox_2"));
-        assertThat(results.get(1).getInstanceType(), is(InstanceType.PRIMARY));
-        assertThat(results.get(1).getStatus(), is("GOOD"));
-        assertThat(results.get(1).getReceiveDelayMs(), is(0L));
-        assertThat(results.get(1).getReplayDelayMs(), is(0L));
-        assertThat(results.get(1).getEntryCount(), is(3038L));
-    }
-
-    @Test
     public void convert_withErrors() {
         TextCommandRunner.Response response = new TextCommandRunner.Response(Collections.emptyList(), Collections.singletonList("test-error"));
         ReplicationStatus status = replicationStatusConverter.convert(response);


### PR DESCRIPTION
Jira link  
[https://tools.hmcts.net/jira/browse/SIDM-10355](https://tools.hmcts.net/jira/browse/SIDM-10355)

Change description

`src/main/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverter.java`

Updated the parser to accept the current DS8 `dsrepl status --showReplicas` row shape with 7 fields.

This was needed because live sandbox rows now include a trailing `Hostname` column. Before this change, valid rows were rejected with `Unable to parse ... length was '7'`, which left `replicationMonitor = UNKNOWN`.


```text
ReplicationStatusConverter Context 'ou=am-config': Unable to parse
'├─ DS/forgerock_ds_tokenstore_idam_sandbox_1  GOOD  0  0  1807  forgerock-ds-tokenstore-idam-sandbox-1.service.core-compute-idam-sandbox.internal',
length was '7'
ReplicationCommandProbe ReplicationCommand: Command completed with no replication info present
```

`src/test/java/uk/gov/hmcts/reform/idam/health/command/ReplicationStatusConverterTest.java`

Updated the existing test rows from 6 fields to 7 fields so they match the current DS8 output format.

This was needed so the tests reflect the new parser behaviour and the full build passes cleanly.

Testing

Ran full build successfully:

`JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew clean build`

Built the exact PR jar and deployed it to sandbox successfully.

Verified live sandbox result:
- tokenstore 1/2/3: `replicationMonitor = UP`
- userstore 2/3: `replicationMonitor = UP`
- userstore 1: unchanged expected `pessimist DOWN`
